### PR TITLE
Adding check for template errors

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -95,7 +95,9 @@ func processPath(curPath, templateDir, output string) error {
 		return nil
 	case mode.IsRegular():
 		// Template file, process accordingly
-		getVarsFromUser(curPath)
+		if err := getVarsFromUser(curPath); err != nil {
+			return err
+		}
 		return tmpl.CreateFileFromTemplate(curPath, destination)
 	}
 

--- a/pkg/tmpl/tmpl.go
+++ b/pkg/tmpl/tmpl.go
@@ -2,6 +2,7 @@ package tmpl
 
 import (
 	"bytes"
+	"errors"
 	"io/ioutil"
 	"os"
 	"regexp"
@@ -37,6 +38,9 @@ func CreateFileFromTemplate(input, output string) error {
 func ScanTemplateForVars(templateFile string) ([]string, error) {
 	buf := &bytes.Buffer{}
 	t, err := getTemplateObject(templateFile)
+	if err != nil {
+		return nil, errors.New(err.Error() + " in file " + templateFile)
+	}
 	r := regexp.MustCompile(`map has no entry for key "([^ ]+?)"`)
 	varList := []string{}
 

--- a/pkg/tmpl/tmpl_test.go
+++ b/pkg/tmpl/tmpl_test.go
@@ -12,6 +12,7 @@ import (
 func TestPkgTmpl(t *testing.T) {
 	t.Run("CreateFileFromTemplate", testCreateFile)
 	t.Run("ScanTemplateForVars", testScanTemplateForVars)
+	t.Run("ScanTemplateForVarsInvalid", testScanTemplateForVarsInvalid)
 }
 
 func testCreateFile(t *testing.T) {
@@ -36,5 +37,14 @@ func testScanTemplateForVars(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, varList, 1)
 	assert.Equal(t, varList[0], varName)
+	assert.NoError(t, os.Remove(tmplFile))
+}
+
+func testScanTemplateForVarsInvalid(t *testing.T) {
+	tmplFile := ".testing.tmpl"
+	assert.NoError(t, testhelpers.CreateFileWithContents(tmplFile, "{{ doesntexist.ForSure }} - {{ .TemplateFileName }}"))
+	_, err := ScanTemplateForVars(tmplFile)
+
+	assert.Error(t, err)
 	assert.NoError(t, os.Remove(tmplFile))
 }


### PR DESCRIPTION
This adds additional checks so ggft doesn't panic when a template error is found during the variable scanning step. The flip side of this, is the template example given in #6 also needs to be updated to escape the "{{ ... }}" syntax properly in many of the files.

The example run now looks like this when this PR is merged:

```text
ggft new ri aks
2020/08/17 20:21:10 template: :17: function "github" not defined in file /home/matts/.ggft/templates/ri/.github/workflows/github-settings.yml
```

Closes #6 